### PR TITLE
:bug: fix cache regressions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -25,9 +25,9 @@ dependencies = [
 
 [[package]]
 name = "alfred_workflow_rs"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10c306988a991853d2fe7215a2b283b0d6d4874e0c30cb4cac76e674326d8514"
+checksum = "d9b90a12b4d637223d6793f34ec47e9e469514f0edb940645facac278c529d1d"
 dependencies = [
  "cached",
  "md5",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "alfred_tailwindcss_docs"
-version = "2.4.1"
+version = "2.4.2"
 dependencies = [
  "alfred_workflow_rs",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "alfred_tailwindcss_docs"
-version = "2.4.1"
+version = "2.4.2"
 edition = "2024"
 rust-version = "1.88"
 description = "Search the Tailwind CSS documentation using Alfred."

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT"
 publish = false
 
 [dependencies]
-alfred_workflow_rs = "1.0"
+alfred_workflow_rs = "1.0.1"
 anyhow = "1.0"
 dotenvy = "0.15"
 html-escape = "0.2.15"

--- a/src/main.rs
+++ b/src/main.rs
@@ -131,7 +131,7 @@ where
 fn configure_cache(workflow: &mut Workflow, query: &str, settings: &WorkflowSettings) {
     if settings.use_alfred_cache {
         workflow.set_use_automatic_cache(true);
-    } else if settings.use_file_cache {
+    } else if settings.use_file_cache && !query.is_empty() {
         workflow.set_cache_key(Some(file_cache_key(query, &settings.tailwind_version)));
         workflow.set_max_cache_entries(settings.file_cache_max_entries);
     }

--- a/src/tests/main.rs
+++ b/src/tests/main.rs
@@ -81,11 +81,45 @@ fn empty_query_shows_placeholder_without_searching() -> Result<()> {
 }
 
 #[test]
+fn empty_query_does_not_enter_file_cache() -> Result<()> {
+    let directory = tempfile::tempdir()?;
+    let mut settings = settings("v4");
+    settings.use_file_cache = true;
+    let search_calls = Cell::new(0);
+    let cli = Cli::default();
+    let mut first = Workflow::with_file_cache(FileCache::with_path(directory.path()));
+
+    populate_workflow_with(&mut first, &cli, &settings, |_, _| {
+        search_calls.set(search_calls.get() + 1);
+        Ok(Vec::new())
+    })?;
+
+    let mut second = Workflow::with_file_cache(FileCache::with_path(directory.path()));
+    populate_workflow_with(&mut second, &cli, &settings, |_, _| {
+        search_calls.set(search_calls.get() + 1);
+        Ok(Vec::new())
+    })?;
+
+    assert_eq!(
+        (
+            search_calls.get(),
+            first.cache_key(),
+            first.get_items()?.len(),
+            second.cache_key(),
+            second.get_items()?.len(),
+        ),
+        (0, None, 1, None, 1)
+    );
+    Ok(())
+}
+
+#[test]
 fn file_cache_hit_bypasses_algolia() -> Result<()> {
     let directory = tempfile::tempdir()?;
     let mut cached = Workflow::with_file_cache(FileCache::with_path(directory.path()));
     cached.set_cache_key(Some("background_v4"));
-    cached.add_item(Item::new("cached result"))?;
+    let cached_item = google_fallback_item("background")?;
+    cached.add_item(cached_item.clone())?;
 
     let mut workflow = Workflow::with_file_cache(FileCache::with_path(directory.path()));
     let mut settings = settings("v4");
@@ -101,10 +135,8 @@ fn file_cache_hit_bypasses_algolia() -> Result<()> {
         Ok(Vec::new())
     })?;
 
-    assert_eq!(
-        (search_calls.get(), workflow.get_items()?.items()[0].title()),
-        (0, "cached result")
-    );
+    assert_eq!(search_calls.get(), 0);
+    assert_eq!(workflow.get_items()?.items(), &[cached_item]);
     Ok(())
 }
 


### PR DESCRIPTION
This pull request makes a minor update to the workflow's caching logic and tests, ensuring that file caching is not used for empty queries. It also bumps the version and dependency for `alfred_workflow_rs`.

**Caching logic improvements:**

* Updated `configure_cache` in `src/main.rs` to prevent the file cache from being used when the query string is empty, even if `use_file_cache` is enabled.

**Testing improvements:**

* Added a new test `empty_query_does_not_enter_file_cache` in `src/tests/main.rs` to verify that empty queries do not use the file cache and do not trigger unnecessary searches.
* Improved the `file_cache_hit_bypasses_algolia` test to use a realistic cached item and more precise assertions.

**Dependency and version updates:**

* Bumped the crate version to `2.4.2` and updated the `alfred_workflow_rs` dependency to `1.0.1` in `Cargo.toml`.